### PR TITLE
Enable call params

### DIFF
--- a/.github/workflows/deno.yaml
+++ b/.github/workflows/deno.yaml
@@ -1,0 +1,21 @@
+name: deno
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: denoland/setup-deno@v1
+      - run: deno test
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: denoland/setup-deno@v1
+      - run: deno fmt --check
+      - run: deno lint
+      - run: deno check *.ts

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ conn.close();
 ```
 
 ## Acknowledgements
+
 I used the following code as a reference.
 
-* https://github.com/lambdalisue/deno-msgpack-rpc
-* https://github.com/hrsh7th/deno-json-rpc
-* https://pkg.go.dev/golang.org/x/tools/internal/jsonrpc2
+- https://github.com/lambdalisue/deno-msgpack-rpc
+- https://github.com/hrsh7th/deno-json-rpc
+- https://pkg.go.dev/golang.org/x/tools/internal/jsonrpc2

--- a/connection.ts
+++ b/connection.ts
@@ -45,12 +45,13 @@ export class Connection {
     await this.#stream.send(msg);
   }
 
-  async call(method: string, ..._params: unknown[]): Promise<ResponseMessage> {
+  async call(method: string, ...params: unknown[]): Promise<ResponseMessage> {
     const msgId = this.#msgIdGen.generateId();
     const msg: RequestMessage = {
       jsonrpc: "2.0",
       id: msgId,
       method: method,
+      params: params,
     };
 
     await this.#stream.send(msg);

--- a/connection_test.ts
+++ b/connection_test.ts
@@ -53,3 +53,54 @@ Deno.test("call", async () => {
 
   assertEquals(res, { jsonrpc: "2.0", id: 1, result: "hoge" });
 });
+
+Deno.test("call with params", async () => {
+  const p1 = new Buffer();
+  const p2 = new Buffer();
+  const serverStream = new VSCodeStream(p1, p2);
+  const clientStream = new VSCodeStream(p2, p1);
+
+  const h = (mes: RequestMessage): Promise<ResponseMessage> => {
+    if (mes.method === "testWithParams") {
+      const res: ResponseMessage = {
+        jsonrpc: "2.0",
+        id: mes.id,
+        result: `params: ${JSON.stringify(mes.params)}`,
+      };
+      return Promise.resolve(res);
+    }
+
+    const res: ResponseMessage = {
+      jsonrpc: "2.0",
+      id: mes.id,
+      error: {
+        code: -32601,
+        message: "not found",
+      },
+    };
+    return Promise.resolve(res);
+  };
+
+  const nh = (_mes: NotificationMessage): Promise<void> => Promise.resolve();
+
+  const serverConn = new Connection(serverStream, { handle: h }, {
+    handle: nh,
+  });
+  const clientConn = new Connection(clientStream, { handle: h }, {
+    handle: nh,
+  });
+
+  serverConn.listen();
+  clientConn.listen();
+
+  const res = await clientConn.call("testWithParams", "hoge", "fuga");
+
+  clientConn.close();
+  serverConn.close();
+
+  assertEquals(res, {
+    jsonrpc: "2.0",
+    id: 1,
+    result: `params: ["hoge","fuga"]`,
+  });
+});


### PR DESCRIPTION
This enables params when using `connection.call(method, ...params)`.

Also sets up GitHub Action with `deno test` etc.